### PR TITLE
Add Garage & Shade controller

### DIFF
--- a/home_assistant.xml
+++ b/home_assistant.xml
@@ -3,10 +3,10 @@
     <notes>
 
     </notes>
-    
+
     <component_properties>
     </component_properties>
-    
+
     <control_interfaces preferred="ip">
         <ip port="8123" response_time_length_ms="500" reconnect_timeout_ms="10" protocol="http">
             <http_header name="Authorization">Bearer TOKEN</http_header>
@@ -23,7 +23,7 @@
         <internal name_on_component="Lighting Controller">
             <environmental_media></environmental_media>
             <resource resource_type="ENV_LIGHTINGCONTROLLER_SOURCE"/>
-			<resource resource_type="ENV_FANCONTROLLER_SOURCE"/>
+            <resource resource_type="ENV_FANCONTROLLER_SOURCE"/>
         </internal>
         <internal name_on_component="GarageDoorController">
             <environmental_media></environmental_media>
@@ -129,40 +129,40 @@
                 </command_interface>
             </action>
 
-			<action name="DimmerSet">
+            <action name="DimmerSet">
                 <action_argument name="Address1" note="Entity ID"/>
-				<action_argument name="Address2" note="not used"></action_argument>
-				<action_argument name="Address3" note="not used"></action_argument>
-				<action_argument name="Address4" note="not used"></action_argument>
-				<action_argument name="Address5" note="not used"></action_argument>
-				<action_argument name="Address6" note="not used"></action_argument>
-				<action_argument name="DimmerLevel" note="Select the Dimmer Level 0 - 100"></action_argument>
-				<action_argument name="DelayTime" note="not used"></action_argument>
-				<action_argument name="FadeTime" note="not used"></action_argument>
-				<command_interface interface="ip">
-					<command response_required="no">
+                <action_argument name="Address2" note="not used"></action_argument>
+                <action_argument name="Address3" note="not used"></action_argument>
+                <action_argument name="Address4" note="not used"></action_argument>
+                <action_argument name="Address5" note="not used"></action_argument>
+                <action_argument name="Address6" note="not used"></action_argument>
+                <action_argument name="DimmerLevel" note="Select the Dimmer Level 0 - 100"></action_argument>
+                <action_argument name="DelayTime" note="not used"></action_argument>
+                <action_argument name="FadeTime" note="not used"></action_argument>
+                <command_interface interface="ip">
+                    <command response_required="no">
                         <command_string http_request_type="POST" type="character">api/services/light/turn_on</command_string>
                         <http_header name="Content-Type">application/json</http_header>
                         <parameter_list>
                             <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
                             <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1"></parameter>
                             <parameter parameter_data_type="character" isHttpBody="true">&quot;, &quot;brightness_pct&quot;: &quot;</parameter>
-							<parameter parameter_data_type="character" isHttpBody="true" action_argument="DimmerLevel"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="DimmerLevel"></parameter>
                             <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
                         </parameter_list>
-						<delay ms_delay="500"/>
-					</command>
-				</command_interface>
-			</action>
+                        <delay ms_delay="500"/>
+                    </command>
+                </command_interface>
+            </action>
 
-			<entity address_components="1" name="Dimmer Group">
-				<slider_representation>
-					<press_action name="DimmerSet"></press_action>
-					<valueSource name="DimmerLevel">
-						<unique_identifier address_component="1" name="DimmerLevel"></unique_identifier>
-					</valueSource>
-				</slider_representation>
-			</entity>
+            <entity address_components="1" name="Dimmer Group">
+                <slider_representation>
+                    <press_action name="DimmerSet"></press_action>
+                    <valueSource name="DimmerLevel">
+                        <unique_identifier address_component="1" name="DimmerLevel"></unique_identifier>
+                    </valueSource>
+                </slider_representation>
+            </entity>
 
             <entity name="Switch" address_components="1">
                 <toggle_button_representation>
@@ -196,7 +196,7 @@
                 <action_argument name="GarageDoorAddress2" note="not used"/>
                 <update_state_variable name="GarageDoorStatus_*" update_type="set" update_source="constant" wildcard_format="%d" wildcard_source="action_argument" wildcard_source_name="GarageDoorAddress">Closed</update_state_variable>
                 <command_interface interface="ip">
-					<command response_required="no">
+                    <command response_required="no">
                         <command_string http_request_type="POST" type="character">api/services/cover/close_cover</command_string>
                         <http_header name="Content-Type">application/json</http_header>
                         <parameter_list>
@@ -204,8 +204,8 @@
                             <parameter parameter_data_type="character" isHttpBody="true" action_argument="GarageDoorAddress"></parameter>
                             <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
                         </parameter_list>
-						<delay ms_delay="500"/>
-					</command>
+                        <delay ms_delay="500"/>
+                    </command>
                 </command_interface>
             </action>
 
@@ -214,7 +214,7 @@
                 <action_argument name="GarageDoorAddress2" note="not used"/>
                 <update_state_variable name="GarageDoorStatus_*" update_type="set" update_source="constant" wildcard_format="%d" wildcard_source="action_argument" wildcard_source_name="GarageDoorAddress">Open</update_state_variable>
                 <command_interface interface="ip">
-					<command response_required="no">
+                    <command response_required="no">
                         <command_string http_request_type="POST" type="character">api/services/cover/open_cover</command_string>
                         <http_header name="Content-Type">application/json</http_header>
                         <parameter_list>
@@ -222,8 +222,8 @@
                             <parameter parameter_data_type="character" isHttpBody="true" action_argument="GarageDoorAddress"></parameter>
                             <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
                         </parameter_list>
-						<delay ms_delay="500"/>
-					</command>
+                        <delay ms_delay="500"/>
+                    </command>
                 </command_interface>
             </action>
 

--- a/home_assistant.xml
+++ b/home_assistant.xml
@@ -1,247 +1,321 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="racepoint_component_profile.xsd" manufacturer="Home" model="Assistant" alias="Home Assistant" device_class="Lighting_controller" rpm_xml_version="1.10" minimum_component_engine_version="9.2">
-   <notes />
-   <component_properties />
-   <control_interfaces preferred="ip">
-      <ip port="8123" response_time_length_ms="500" reconnect_timeout_ms="10" protocol="http">
-         <http_header name="Authorization">Bearer TOKEN</http_header>
-      </ip>
-   </control_interfaces>
-   <media_interfaces>
-      <data name_on_component="ETHERNET">
-         <combined_media>
-            <data_media type="ethernet" />
-            <control port="8123" />
-         </combined_media>
-      </data>
-      <internal name_on_component="Lighting Controller">
-         <environmental_media />
-         <resource resource_type="ENV_LIGHTINGCONTROLLER_SOURCE" />
-         <resource resource_type="ENV_FANCONTROLLER_SOURCE" />
-      </internal>
-   </media_interfaces>
-   <state_variable_list>
-      <state_variable name="FanSet_0" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Off">0</state_variable>
-      <state_variable name="FanSet_1" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Low">2</state_variable>
-      <state_variable name="FanSet_2" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Mid">4</state_variable>
-      <state_variable name="FanSet_3" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed High">7</state_variable>
-   </state_variable_list>
-   <logical_component logical_component_name="Home Assistant">
-      <implementation>
-         <internal name_on_component="Lighting Controller" />
-      </implementation>
-      <resource_component_actions resource_type="ENV_FANCONTROLLER_SOURCE">
-         <action name="FanSet">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="not used" />
-            <action_argument name="Address3" note="not used" />
-            <action_argument name="Address4" note="not used" />
-            <action_argument name="Address5" note="not used" />
-            <action_argument name="Address6" note="not used" />
-            <action_argument name="FanSpeed" note="Fan Speed 0 - 3" />
-            <command_interface interface="ip">
-               <command response_required="no">
-                  <command_string http_request_type="POST" type="character">api/services/fan/turn_on</command_string>
-                  <http_header name="Content-Type">application/json</http_header>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" isHttpBody="true">{"entity_id": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1" />
-                     <parameter parameter_data_type="character" isHttpBody="true">", "speed": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" state_variable="FanSet_*" wildcard_source="action_argument" wildcard_source_name="FanSpeed" />
-                     <parameter parameter_data_type="character" isHttpBody="true">"}</parameter>
-                  </parameter_list>
-                  <delay ms_delay="500" />
-               </command>
-            </command_interface>
-         </action>
-         <entity name="Fan" address_components="2">
-            <slider_representation>
-               <press_action name="FanSet" />
-               <valueSource name="CurrentDimmerLevel">
-                  <unique_identifier name="Needed" address_component="2" />
-                  <unique_identifier name="DeviceID" address_component="1" />
-               </valueSource>
-            </slider_representation>
-            <query_status_with_action name="QueryFanState" period_ms="10000">
-               <with_arg name="Address1" address_component="1" format="%s" />
-            </query_status_with_action>
-         </entity>
-      </resource_component_actions>
-      <resource_component_actions resource_type="ENV_LIGHTINGCONTROLLER_SOURCE">
-         <action name="SwitchOn">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="" />
-            <action_argument name="Address3" note="" />
-            <action_argument name="Address4" note="" />
-            <action_argument name="Address5" note="" />
-            <action_argument name="Address6" note="" />
-            <command_interface interface="ip">
-               <command response_required="no">
-                  <command_string http_request_type="POST" type="character">api/services/light/turn_on</command_string>
-                  <http_header name="Content-Type">application/json</http_header>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" isHttpBody="true">{"entity_id": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1" />
-                     <parameter parameter_data_type="character" isHttpBody="true">"}</parameter>
-                  </parameter_list>
-                  <delay ms_delay="10" />
-               </command>
-            </command_interface>
-         </action>
-         <action name="SwitchOff">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="" />
-            <action_argument name="Address3" note="" />
-            <action_argument name="Address4" note="" />
-            <action_argument name="Address5" note="" />
-            <action_argument name="Address6" note="" />
-            <command_interface interface="ip">
-               <command response_required="no">
-                  <command_string http_request_type="POST" type="character">api/services/light/turn_off</command_string>
-                  <http_header name="Content-Type">application/json</http_header>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" isHttpBody="true">{"entity_id": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1" />
-                     <parameter parameter_data_type="character" isHttpBody="true">"}</parameter>
-                  </parameter_list>
-                  <delay ms_delay="10" />
-               </command>
-            </command_interface>
-         </action>
-         <action name="DimmerSet">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="not used" />
-            <action_argument name="Address3" note="not used" />
-            <action_argument name="Address4" note="not used" />
-            <action_argument name="Address5" note="not used" />
-            <action_argument name="Address6" note="not used" />
-            <action_argument name="DimmerLevel" note="Select the Dimmer Level 0 - 100" />
-            <action_argument name="DelayTime" note="not used" />
-            <action_argument name="FadeTime" note="not used" />
-            <command_interface interface="ip">
-               <command response_required="no">
-                  <command_string http_request_type="POST" type="character">api/services/light/turn_on</command_string>
-                  <http_header name="Content-Type">application/json</http_header>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" action_argument="DimmerLevel" />
-                     <parameter parameter_data_type="character" isHttpBody="true">{"entity_id": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1" />
-                     <parameter parameter_data_type="character" isHttpBody="true">", "brightness_pct": "</parameter>
-                     <parameter parameter_data_type="character" isHttpBody="true" action_argument="DimmerLevel" />
-                     <parameter parameter_data_type="character" isHttpBody="true">"}</parameter>
-                  </parameter_list>
-                  <delay ms_delay="500" />
-               </command>
-            </command_interface>
-         </action>
-         <entity address_components="1" name="Dimmer Group">
-            <slider_representation>
-               <press_action name="DimmerSet" />
-               <valueSource name="DimmerLevel">
-                  <unique_identifier address_component="1" name="DimmerLevel" />
-               </valueSource>
-            </slider_representation>
-         </entity>
-         <entity name="Switch" address_components="1">
-            <toggle_button_representation>
-               <release_action name="SwitchOn" />
-               <toggle_release_action name="SwitchOff" />
-               <osd_press_action name="SwitchOn" />
-               <osd_hold_action name="SwitchOff" />
-               <toggleOnUsingState name="isLightOn">
-                  <unique_identifier name="CurrentLightNumber" address_component="1" />
-               </toggleOnUsingState>
-            </toggle_button_representation>
-            <query_status_with_action name="QueryLightState" period_ms="10000">
-               <with_arg name="Address1" address_component="1" format="%s" />
-            </query_status_with_action>
-            <query_status_with_action name="UpdateIfLightIsOn" period_ms="60000">
-               <with_arg name="Address1" address_component="1" format="%d" />
-            </query_status_with_action>
-            <query_status_with_action name="UpdateIfLightIsOff" period_ms="60000">
-               <with_arg name="Address1" address_component="1" format="%d" />
-            </query_status_with_action>
-         </entity>
-      </resource_component_actions>
-      <custom_component_actions>
-         <action name="QueryLightState">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="not used" />
-            <action_argument name="Address3" note="not used" />
-            <action_argument name="Address4" note="not used" />
-            <action_argument name="Address5" note="not used" />
-            <action_argument name="Address6" note="not used" />
-            <update_state_variable name="CurrentLightNumber" update_type="set" update_source="action_argument">Address1</update_state_variable>
-            <command_interface interface="ip">
-               <command response_required="yes">
-                  <http_header name="Content-Type">application/json</http_header>
-                  <command_string http_request_type="GET" type="character">api/states/</command_string>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" isHttpBody="false" action_argument="Address1" />
-                  </parameter_list>
-                  <response_codes>
-                     <rspmessage status="success" name="HassLightOn">
-                        <constant type="character">200</constant>
-                        <root_object name="none" matches_required="at_least_one" format="json">
-                           <values path="//state" matches_required="at_least_one">
-                              <value_map match_required="yes">
-                                 <map key="off">
-                                    <update state="LightPowerStatus" type="string">OFF</update>
-                                    <update state="isLightOn" type="boolean">false</update>
-                                 </map>
-                                 <map key="on">
-                                    <update state="LightPowerStatus" type="string">ON</update>
-                                    <update state="isLightOn" type="boolean">true</update>
-                                 </map>
-                              </value_map>
-                           </values>
-                        </root_object>
-                        <append_data_to_state_names state="CurrentLightNumber" />
-                     </rspmessage>
-                  </response_codes>
-                  <delay ms_delay="50" />
-               </command>
-            </command_interface>
-         </action>
-         <action name="QueryFanState">
-            <action_argument name="Address1" note="Entity ID" />
-            <action_argument name="Address2" note="not used" />
-            <action_argument name="Address3" note="not used" />
-            <action_argument name="Address4" note="not used" />
-            <action_argument name="Address5" note="not used" />
-            <action_argument name="Address6" note="not used" />
-            <update_state_variable name="CurrentLightNumber" update_type="set" update_source="action_argument">Address1</update_state_variable>
-            <command_interface interface="ip">
-               <command response_required="yes">
-                  <http_header name="Content-Type">application/json</http_header>
-                  <command_string http_request_type="GET" type="character">api/states/</command_string>
-                  <parameter_list>
-                     <parameter parameter_data_type="character" isHttpBody="false" action_argument="Address1" />
-                  </parameter_list>
-                  <response_codes>
-                     <rspmessage status="success" name="HassLightOn">
-                        <constant type="character">200</constant>
-                        <root_object name="none" matches_required="at_least_one" format="json">
-                           <values path="//state" matches_required="at_least_one">
-                              <value_map match_required="yes">
-                                 <map key="off">
-                                    <update state="LightPowerStatus" type="string">OFF</update>
-                                    <update state="isLightOn" type="boolean">false</update>
-                                 </map>
-                                 <map key="on">
-                                    <update state="LightPowerStatus" type="string">ON</update>
-                                    <update state="isLightOn" type="boolean">true</update>
-                                 </map>
-                              </value_map>
-                           </values>
-                        </root_object>
-                        <append_data_to_state_names state="CurrentLightNumber" />
-                     </rspmessage>
-                  </response_codes>
-                  <delay ms_delay="50" />
-               </command>
-            </command_interface>
-         </action>
-      </custom_component_actions>
-   </logical_component>
+<component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="racepoint_component_profile.xsd" manufacturer="Home" model="Assistant" alias="Home Assistant" device_class="Lighting_controller" rpm_xml_version="1.11" minimum_component_engine_version="9.2">
+    <notes>
+
+    </notes>
+    
+    <component_properties>
+    </component_properties>
+    
+    <control_interfaces preferred="ip">
+        <ip port="8123" response_time_length_ms="500" reconnect_timeout_ms="10" protocol="http">
+            <http_header name="Authorization">Bearer TOKEN</http_header>
+        </ip>
+    </control_interfaces>
+
+    <media_interfaces>
+        <data name_on_component="ETHERNET">
+            <combined_media>
+                <data_media type="ethernet"/>
+                <control port="8123"/>
+            </combined_media>
+        </data>
+        <internal name_on_component="Lighting Controller">
+            <environmental_media></environmental_media>
+            <resource resource_type="ENV_LIGHTINGCONTROLLER_SOURCE"/>
+			<resource resource_type="ENV_FANCONTROLLER_SOURCE"/>
+        </internal>
+        <internal name_on_component="GarageDoorController">
+            <environmental_media></environmental_media>
+            <resource resource_type="ENV_GARAGE_DOOR_SOURCE"></resource>
+        </internal>
+    </media_interfaces>
+
+    <state_variable_list>
+        <state_variable name="IsDoorLocked" owning_logical_component="Security_system" state_center_type="boolean" state_center_binding="IsDoorLocked">0</state_variable>
+        <dynamic_state_variable name="DoorLockStatus" owning_logical_component="Security_system" state_center_type="string" state_center_binding="DoorLockStatus"></dynamic_state_variable>
+        <dynamic_state_variable name="GarageDoorStatus" owning_logical_component="Security_system" state_center_type="string" state_center_binding="GarageDoorStatus"></dynamic_state_variable>
+
+        <state_variable name="FanSet_0" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Off">0</state_variable>
+        <state_variable name="FanSet_1" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Low">2</state_variable>
+        <state_variable name="FanSet_2" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed Mid">4</state_variable>
+        <state_variable name="FanSet_3" owning_logical_component="Home Assistant" user_editable="yes" note="Fan Speed High">7</state_variable>
+    </state_variable_list>
+
+    <logical_component logical_component_name="Home Assistant">
+        <implementation>
+            <internal name_on_component="Lighting Controller"></internal>
+        </implementation>
+
+        <resource_component_actions resource_type="ENV_FANCONTROLLER_SOURCE">
+            <action name="FanSet">
+                <action_argument name="Address1" note="Entity ID"/>
+                <action_argument name="Address2" note="not used"/>
+                <action_argument name="Address3" note="not used"/>
+                <action_argument name="Address4" note="not used"/>
+                <action_argument name="Address5" note="not used"/>
+                <action_argument name="Address6" note="not used"/>
+                <action_argument name="FanSpeed" note="Fan Speed 0 - 3"/>
+                <command_interface interface="ip">
+                    <command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/fan/turn_on</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;, &quot;speed&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" state_variable="FanSet_*" wildcard_source="action_argument" wildcard_source_name="FanSpeed"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+                        <delay ms_delay="500"/>
+                    </command>
+                </command_interface>
+            </action>
+
+            <entity name="Fan" address_components="2">
+                <slider_representation>
+                    <press_action name="FanSet"></press_action>
+                    <valueSource name="CurrentDimmerLevel">
+                        <unique_identifier name="Needed" address_component="2"/>
+                        <unique_identifier name="DeviceID" address_component="1"/>
+                    </valueSource>
+                </slider_representation>
+                <query_status_with_action name="QueryFanState" period_ms="10000">
+                    <with_arg name="Address1" address_component="1" format="%s"/>
+                </query_status_with_action>
+            </entity>
+        </resource_component_actions>
+
+        <resource_component_actions resource_type="ENV_LIGHTINGCONTROLLER_SOURCE">
+            <action name="SwitchOn">
+                <action_argument name="Address1" note="Entity ID"/>
+                <action_argument name="Address2" note=""/>
+                <action_argument name="Address3" note=""/>
+                <action_argument name="Address4" note=""/>
+                <action_argument name="Address5" note=""/>
+                <action_argument name="Address6" note=""/>
+                <command_interface interface="ip">
+                    <command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/light/turn_on</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+                        <delay ms_delay="10"/>
+                    </command>
+                </command_interface>
+            </action>
+
+            <action name="SwitchOff">
+                <action_argument name="Address1" note="Entity ID"/>
+                <action_argument name="Address2" note=""/>
+                <action_argument name="Address3" note=""/>
+                <action_argument name="Address4" note=""/>
+                <action_argument name="Address5" note=""/>
+                <action_argument name="Address6" note=""/>
+                <command_interface interface="ip">
+                    <command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/light/turn_off</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+                        <delay ms_delay="10"/>
+                    </command>
+                </command_interface>
+            </action>
+
+			<action name="DimmerSet">
+                <action_argument name="Address1" note="Entity ID"/>
+				<action_argument name="Address2" note="not used"></action_argument>
+				<action_argument name="Address3" note="not used"></action_argument>
+				<action_argument name="Address4" note="not used"></action_argument>
+				<action_argument name="Address5" note="not used"></action_argument>
+				<action_argument name="Address6" note="not used"></action_argument>
+				<action_argument name="DimmerLevel" note="Select the Dimmer Level 0 - 100"></action_argument>
+				<action_argument name="DelayTime" note="not used"></action_argument>
+				<action_argument name="FadeTime" note="not used"></action_argument>
+				<command_interface interface="ip">
+					<command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/light/turn_on</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="Address1"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;, &quot;brightness_pct&quot;: &quot;</parameter>
+							<parameter parameter_data_type="character" isHttpBody="true" action_argument="DimmerLevel"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+						<delay ms_delay="500"/>
+					</command>
+				</command_interface>
+			</action>
+
+			<entity address_components="1" name="Dimmer Group">
+				<slider_representation>
+					<press_action name="DimmerSet"></press_action>
+					<valueSource name="DimmerLevel">
+						<unique_identifier address_component="1" name="DimmerLevel"></unique_identifier>
+					</valueSource>
+				</slider_representation>
+			</entity>
+
+            <entity name="Switch" address_components="1">
+                <toggle_button_representation>
+                    <release_action name="SwitchOn">
+                    </release_action>
+                    <toggle_release_action name="SwitchOff">
+                    </toggle_release_action>
+                    <osd_press_action name="SwitchOn">
+                    </osd_press_action>
+                    <osd_hold_action name="SwitchOff">
+                    </osd_hold_action>
+                    <toggleOnUsingState name="isLightOn">
+                        <unique_identifier name="CurrentLightNumber" address_component="1"/>
+                    </toggleOnUsingState>
+                </toggle_button_representation>
+                <query_status_with_action name="QueryLightState" period_ms="10000">
+                    <with_arg name="Address1" address_component="1" format="%s"/>
+                </query_status_with_action>
+                <query_status_with_action name="UpdateIfLightIsOn" period_ms="60000">
+                    <with_arg name="Address1" address_component="1" format="%d"/>
+                </query_status_with_action>
+                <query_status_with_action name="UpdateIfLightIsOff" period_ms="60000">
+                    <with_arg name="Address1" address_component="1" format="%d"/>
+                </query_status_with_action>
+            </entity>
+        </resource_component_actions>
+
+        <resource_component_actions resource_type="ENV_GARAGE_DOOR_SOURCE">
+            <action name="CloseGarageDoor">
+                <action_argument name="GarageDoorAddress" note="Device Number"/>
+                <action_argument name="GarageDoorAddress2" note="not used"/>
+                <update_state_variable name="GarageDoorStatus_*" update_type="set" update_source="constant" wildcard_format="%d" wildcard_source="action_argument" wildcard_source_name="GarageDoorAddress">Closed</update_state_variable>
+                <command_interface interface="ip">
+					<command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/cover/close_cover</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="GarageDoorAddress"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+						<delay ms_delay="500"/>
+					</command>
+                </command_interface>
+            </action>
+
+            <action name="OpenGarageDoor">
+                <action_argument name="GarageDoorAddress" note="Device Number"/>
+                <action_argument name="GarageDoorAddress2" note="not used"/>
+                <update_state_variable name="GarageDoorStatus_*" update_type="set" update_source="constant" wildcard_format="%d" wildcard_source="action_argument" wildcard_source_name="GarageDoorAddress">Open</update_state_variable>
+                <command_interface interface="ip">
+					<command response_required="no">
+                        <command_string http_request_type="POST" type="character">api/services/cover/open_cover</command_string>
+                        <http_header name="Content-Type">application/json</http_header>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="true">{&quot;entity_id&quot;: &quot;</parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true" action_argument="GarageDoorAddress"></parameter>
+                            <parameter parameter_data_type="character" isHttpBody="true">&quot;}</parameter>
+                        </parameter_list>
+						<delay ms_delay="500"/>
+					</command>
+                </command_interface>
+            </action>
+
+            <entity name="Garage Door" address_components="1">
+                <toggle_button_representation>
+                    <release_action name="OpenGarageDoor"></release_action>
+                    <toggle_release_action name="CloseGarageDoor"></toggle_release_action>
+                </toggle_button_representation>
+            </entity>
+        </resource_component_actions>
+
+        <custom_component_actions>
+            <action name="QueryLightState">
+                <action_argument name="Address1" note="Entity ID"/>
+                <action_argument name="Address2" note="not used"/>
+                <action_argument name="Address3" note="not used"/>
+                <action_argument name="Address4" note="not used"/>
+                <action_argument name="Address5" note="not used"/>
+                <action_argument name="Address6" note="not used"/>
+                <update_state_variable name="CurrentLightNumber" update_type="set" update_source="action_argument">Address1</update_state_variable>
+                <command_interface interface="ip">
+                    <command response_required="yes">
+                        <http_header name="Content-Type">application/json</http_header>
+                        <command_string http_request_type="GET" type="character">api/states/</command_string>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="false" action_argument="Address1"/>
+                        </parameter_list>
+                        <response_codes>
+                            <rspmessage status="success" name="HassLightOn">
+                                <constant type="character">200</constant>
+                                <root_object name="none" matches_required="at_least_one" format="json">
+                                    <values path="//state" matches_required="at_least_one">
+                                        <value_map match_required="yes">
+                                            <map key="off">
+                                                <update state="LightPowerStatus" type="string">OFF</update>
+                                                <update state="isLightOn" type="boolean">false</update>
+                                            </map>
+                                            <map key="on">
+                                                <update state="LightPowerStatus" type="string">ON</update>
+                                                <update state="isLightOn" type="boolean">true</update>
+                                            </map>
+                                        </value_map>
+                                    </values>
+                                </root_object>
+                                <append_data_to_state_names state="CurrentLightNumber"/>
+                            </rspmessage>
+                        </response_codes>
+                        <delay ms_delay="50"/>
+                    </command>
+                </command_interface>
+            </action>
+
+            <action name="QueryFanState">
+                <action_argument name="Address1" note="Entity ID"/>
+                <action_argument name="Address2" note="not used"/>
+                <action_argument name="Address3" note="not used"/>
+                <action_argument name="Address4" note="not used"/>
+                <action_argument name="Address5" note="not used"/>
+                <action_argument name="Address6" note="not used"/>
+                <update_state_variable name="CurrentLightNumber" update_type="set" update_source="action_argument">Address1</update_state_variable>
+                <command_interface interface="ip">
+                    <command response_required="yes">
+                        <http_header name="Content-Type">application/json</http_header>
+                        <command_string http_request_type="GET" type="character">api/states/</command_string>
+                        <parameter_list>
+                            <parameter parameter_data_type="character" isHttpBody="false" action_argument="Address1"/>
+                        </parameter_list>
+                        <response_codes>
+                            <rspmessage status="success" name="HassLightOn">
+                                <constant type="character">200</constant>
+                                <root_object name="none" matches_required="at_least_one" format="json">
+                                    <values path="//state" matches_required="at_least_one">
+                                        <value_map match_required="yes">
+                                            <map key="off">
+                                                <update state="LightPowerStatus" type="string">OFF</update>
+                                                <update state="isLightOn" type="boolean">false</update>
+                                            </map>
+                                            <map key="on">
+                                                <update state="LightPowerStatus" type="string">ON</update>
+                                                <update state="isLightOn" type="boolean">true</update>
+                                            </map>
+                                        </value_map>
+                                    </values>
+                                </root_object>
+                                <append_data_to_state_names state="CurrentLightNumber"/>
+                            </rspmessage>
+                        </response_codes>
+                        <delay ms_delay="50"/>
+                    </command>
+                </command_interface>
+            </action>
+
+        </custom_component_actions>
+    </logical_component>
 </component>


### PR DESCRIPTION
Home Assistant uses the same `cover` service to control the following types of covers:

- Awnings
- Blinds
- Curtains
- Dampers
- Doors
- Garages
- Gates
- Shades
- Shutters
- Windows

As long as we map their respect resource types we should get all of them to work. Making sure the right state variables are used may be another story.